### PR TITLE
Update RNMK Demo project to use my new Range Slider

### DIFF
--- a/app/sliders.js
+++ b/app/sliders.js
@@ -36,11 +36,19 @@ const SliderWithValue = mdl.Slider.slider()
   .withMax(100)
   .build();
 
+const RangeSlider = mdl.RangeSlider.slider()
+  .withStyle(styles.slider)
+  .withMin(10)
+  .withMax(100)
+  .withMinValue(20)
+  .withMaxValue(75)
+  .build();
+
 class ValueText extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      curValue: 55,
+      curValue: props.initial,
     };
   }
 
@@ -51,7 +59,7 @@ class ValueText extends Component {
   render() {
     return (
       <Text style={styles.legendLabel}>
-            {this.state.curValue.toFixed(2)} ({this.props.rangeText})
+        {this.state.curValue} ({this.props.rangeText})
       </Text>
     );
   }
@@ -61,9 +69,12 @@ class Sliders extends Component {
 
   componentDidMount() {
     const slider = this.refs.sliderWithValue;
+    const ranged = this.refs.rangeSlider;
+
     slider.value = 25;
     setTimeout((() => {
       slider.value = 75;
+      ranged.maxValue = 95;
     }), 1000);
   }
 
@@ -81,9 +92,22 @@ class Sliders extends Component {
           <View style={styles.col}>
             <SliderWithValue
               ref="sliderWithValue"
-              onChange={(curValue) => this.refs.valueText.onChange(curValue)}
+              onChange={(curValue) => this.refs.valueText.onChange(curValue.toFixed(2))}
               />
             <ValueText ref="valueText" rangeText="10~100" />
+          </View>
+        </View>
+        <View style={styles.row}>
+          <View style={styles.col}>
+            <mdl.RangeSlider style={styles.slider}/>
+            <Text style={styles.legendLabel}>Range Slider</Text>
+          </View>
+          <View style={styles.col}>
+            <RangeSlider
+              ref="rangeSlider"
+              onChange={(curValue) => this.refs.rangeValueText.onChange(curValue.min.toFixed(2) + '-' + curValue.max.toFixed(2))}
+              />
+            <ValueText ref="rangeValueText" initial="20.00-75.00" rangeText="10~100" />
           </View>
         </View>
       </View>


### PR DESCRIPTION
As per the contribution guide here is the update to the RNMK Demo project. I included the new sliders on the same page as the standard sliders and attempted to mimic the showcase behavior of the original sliders.

The PR for the Range Slider can be found [here](https://github.com/xinthink/react-native-material-kit/pull/94).
