### PR TITLE
add gradle-download-task as build dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'de.undercouch:gradle-download-task:2.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
This should help with https://github.com/xinthink/rnmk-demo/issues/12 as I think `ReactAndroid` is still built from source within this project
